### PR TITLE
Update to LLVM 20.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Make sure to provide all dependencies required by the project, either by install
 
 ### Dependencies
 
-The project depends on a [patched version](https://github.com/oowekyala/llvm-project) of `LLVM 18.1.6` (`6f89431c3d4de87df6d76cf7ffa73bfa881607b7`).
+The project depends on [LLVM](https://github.com/llvm/llvm-project) version `20.1.1` (`424c2d9`).
 
 ```sh
 # Configure LLVM

--- a/include/quantum-mlir/Dialect/Quantum/Transforms/Passes.h
+++ b/include/quantum-mlir/Dialect/Quantum/Transforms/Passes.h
@@ -27,7 +27,7 @@ void populateQuantumOptimisePatterns(RewritePatternSet &patterns);
 
 /// Adds the legalization pass patterns to @p patterns .
 void populateMultiQubitLegalizationPatterns(
-    OneToNTypeConverter converter,
+    TypeConverter converter,
     RewritePatternSet &patterns);
 
 /// Constructs the lower-funnel-shift pass.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,7 +23,7 @@ configure_lit_site_cfg(
 
 set(TEST_DEPENDS
     FileCheck count not
-    mlir-cpu-runner
+    mlir-runner
     quantum-opt
 )
 

--- a/test/Dialect/Quantum/Transforms/transform_qubits.mlir
+++ b/test/Dialect/Quantum/Transforms/transform_qubits.mlir
@@ -1,5 +1,4 @@
-// RUN: quantum-opt %s --debug --debug-only=greedy-rewriter,dialect-conversion --quantum-multi-qubit-legalize | FileCheck %s
-// --debug-only=dialect-conversion
+// RUN: quantum-opt %s --quantum-multi-qubit-legalize | FileCheck %s
 
 module {
     

--- a/test/Integration/qir-integration-test.mlir
+++ b/test/Integration/qir-integration-test.mlir
@@ -11,7 +11,7 @@
 // RUN:       convert-index-to-llvm, \
 // RUN:       convert-arith-to-llvm, \
 // RUN:       reconcile-unrealized-casts)" | \
-// RUN: mlir-cpu-runner -e entry -entry-point-result=void \
+// RUN: mlir-runner -e entry -entry-point-result=void \
 // RUN:     --shared-libs=%qir_shlibs,%mlir_c_runner_utils | \
 // RUN: FileCheck %s --match-full-lines
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -68,7 +68,7 @@ llvm_config.with_environment('PATH', config.quantum_tools_dir, append_path=True)
 tool_dirs = [config.quantum_tools_dir, config.llvm_tools_dir]
 tools = [
     "quantum-opt",
-    "mlir-cpu-runner",
+    "mlir-runner",
     add_runtime("mlir_runner_utils"),
     add_runtime("mlir_c_runner_utils"),
 ]


### PR DESCRIPTION
This pull request updates the dependency to LLVM 20.1.1. It includes the rewriting of the 1-to-N conversion for multi-valued qubit register types.

Closes #9 