### PR TITLE
Qir-to-quantum

### DIFF
--- a/include/quantum-mlir/Conversion/Passes.h
+++ b/include/quantum-mlir/Conversion/Passes.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "quantum-mlir/Conversion/QIRToLLVM/QIRToLLVM.h"
+#include "quantum-mlir/Conversion/QIRToQuantum/QIRToQuantum.h"
 #include "quantum-mlir/Conversion/QuantumToQIR/QuantumToQIR.h"
 
 namespace mlir::quantum {

--- a/include/quantum-mlir/Conversion/Passes.td
+++ b/include/quantum-mlir/Conversion/Passes.td
@@ -33,5 +33,16 @@ def ConvertQIRToLLVM : Pass<"convert-qir-to-llvm"> {
     ];
 }
 
+def ConvertQIRToQuantum : Pass<"lift-qir-to-quantum"> {
+    let summary = "Perform a dialect lifting from QIR to Quantum";
+
+    let constructor = "mlir::createConvertQIRToQuantumPass()";
+
+    let dependentDialects = [
+        "quantum::QuantumDialect",
+        "qir::QIRDialect",
+        "tensor::TensorDialect"
+    ];
+}
 
 #endif // QUANTUM_MLIR_CONVERSION_PASSES

--- a/include/quantum-mlir/Conversion/QIRToQuantum/QIRToQuantum.h
+++ b/include/quantum-mlir/Conversion/QIRToQuantum/QIRToQuantum.h
@@ -7,19 +7,19 @@ namespace mlir {
 
 //===- Generated includes -------------------------------------------------===//
 
-#define GEN_PASS_DECL_CONVERTQUANTUMTOQIR
+#define GEN_PASS_DECL_CONVERTQIRTOQUANTUM
 #include "quantum-mlir/Conversion/Passes.h.inc"
 
 //===----------------------------------------------------------------------===//
 
-namespace quantum {
+namespace qir {
 
-void populateConvertQuantumToQIRPatterns(
+void populateConvertQIRToQuantumPatterns(
     TypeConverter &typeConverter,
     RewritePatternSet &patterns);
 
-} // namespace quantum
+} // namespace qir
 
-std::unique_ptr<Pass> createConvertQuantumToQIRPass();
+std::unique_ptr<Pass> createConvertQIRToQuantumPass();
 
 } // namespace mlir

--- a/include/quantum-mlir/Conversion/QIRToQuantum/QIRToQuantum.h
+++ b/include/quantum-mlir/Conversion/QIRToQuantum/QIRToQuantum.h
@@ -3,6 +3,8 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
+class QubitMap;
+
 namespace mlir {
 
 //===- Generated includes -------------------------------------------------===//
@@ -16,7 +18,8 @@ namespace qir {
 
 void populateConvertQIRToQuantumPatterns(
     TypeConverter &typeConverter,
-    RewritePatternSet &patterns);
+    RewritePatternSet &patterns,
+    QubitMap &qubitMap);
 
 } // namespace qir
 

--- a/include/quantum-mlir/Dialect/Quantum/IR/QuantumBase.td
+++ b/include/quantum-mlir/Dialect/Quantum/IR/QuantumBase.td
@@ -12,7 +12,6 @@ include "mlir/IR/BuiltinTypes.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/EnumAttr.td"
 
-
 def Quantum_Dialect : Dialect {
     let name = "quantum";
     let cppNamespace = "::mlir::quantum";
@@ -32,7 +31,11 @@ def Quantum_Dialect : Dialect {
         void registerOps();
         void registerTypes();
     }];
-    // let dependentDialects = ["arith::ArithDialect"];
+
+    let dependentDialects = [
+        "arith::ArithDialect"
+    ];
+
     let useDefaultAttributePrinterParser = 0;
     // let useDefaultTypePrinterParser = 1;
 }

--- a/include/quantum-mlir/Dialect/Quantum/IR/QuantumOps.h
+++ b/include/quantum-mlir/Dialect/Quantum/IR/QuantumOps.h
@@ -5,12 +5,14 @@
 #pragma once
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/DLTI/Traits.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/RegionKindInterface.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"

--- a/include/quantum-mlir/Dialect/Quantum/IR/QuantumOps.td
+++ b/include/quantum-mlir/Dialect/Quantum/IR/QuantumOps.td
@@ -309,6 +309,26 @@ def Quantum_HOp : PrimitiveGate_Op<
   let hasFolder = 1;
 }
 
+def Quantum_RzOp : PrimitiveGate_Op<
+        "Rz",
+        [
+          NoMemoryEffect,
+          AllTypesMatch<["input", "result"]>]> {
+  let summary = "z rotation gate operation";
+  let description = [{
+    Example:
+    %theta = arith.constant 0.34 : f64
+    %q1 = "quantum.Rz" (%q0, %theta): !quantum.qubit<1>, f64 -> !quantum.qubit<1>
+  }];
+
+  let arguments = (ins
+    Quantum_QubitType:$input,
+    F64:$theta
+  );
+  let results = (outs Quantum_QubitType:$result);
+  let hasCanonicalizeMethod = 1;
+}
+
 def Quantum_CNOTOp : PrimitiveGate_Op<
         "CNOT",
         [
@@ -368,7 +388,10 @@ def Quantum_ZOp : PrimitiveGate_Op<
 def Quantum_SWAPOp : PrimitiveGate_Op<
         "SWAP",
         [
-          AllTypesMatch<["lhs", "rhs", "result1", "result2"]>]> {
+          AllTypesMatch<
+            [
+              "lhs", "rhs",
+              "result1", "result2"]>]> {
   let summary = "SWAP gate";
   let description = [{
     Swaps the states of two qubits.

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(QuantumToQIR)
+add_subdirectory(QIRToQuantum)
 add_subdirectory(QIRToLLVM)

--- a/lib/Conversion/QIRToQuantum/CMakeLists.txt
+++ b/lib/Conversion/QIRToQuantum/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_mlir_conversion_library(QIRToQuantum
+        QIRToQuantum.cpp
+
+    DEPENDS
+        ConversionIncGen
+
+    LINK_COMPONENTS
+        Core
+
+    LINK_LIBS PUBLIC
+        MLIRDialectUtils
+        MLIRTransformUtils
+        QuantumIR
+        QIRIR
+)

--- a/lib/Conversion/QIRToQuantum/QIRToQuantum.cpp
+++ b/lib/Conversion/QIRToQuantum/QIRToQuantum.cpp
@@ -1,0 +1,141 @@
+/// Implements the ConvertQuantumToQIRPass.
+///
+/// @file
+/// @author     Lars Schütze (lars.schuetze@tu-dresden.de)
+
+#include "quantum-mlir/Conversion/QIRToQuantum/QIRToQuantum.h"
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "quantum-mlir/Dialect/QIR/IR/QIR.h"
+#include "quantum-mlir/Dialect/QIR/IR/QIRBase.h"
+#include "quantum-mlir/Dialect/QIR/IR/QIROps.h"
+#include "quantum-mlir/Dialect/QIR/IR/QIRTypes.h"
+#include "quantum-mlir/Dialect/Quantum/IR/Quantum.h"
+#include "quantum-mlir/Dialect/Quantum/IR/QuantumBase.h"
+#include "quantum-mlir/Dialect/Quantum/IR/QuantumOps.h"
+#include "quantum-mlir/Dialect/Quantum/IR/QuantumTypes.h"
+
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/Support/Casting.h>
+#include <mlir/Dialect/Func/IR/FuncOps.h>
+#include <mlir/Dialect/Tensor/IR/Tensor.h>
+#include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/Types.h>
+#include <mlir/IR/Value.h>
+#include <mlir/IR/ValueRange.h>
+#include <mlir/Support/LogicalResult.h>
+
+using namespace mlir;
+using namespace mlir::qir;
+
+//===- Generated includes -------------------------------------------------===//
+
+namespace mlir {
+
+#define GEN_PASS_DEF_CONVERTQIRTOQUANTUM
+#include "quantum-mlir/Conversion/Passes.h.inc"
+
+} // namespace mlir
+
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct ConvertQIRToQuantumPass
+        : mlir::impl::ConvertQIRToQuantumBase<ConvertQIRToQuantumPass> {
+    using ConvertQIRToQuantumBase::ConvertQIRToQuantumBase;
+
+    void runOnOperation() override;
+};
+
+struct ConvertAlloc : public OpConversionPattern<qir::AllocOp> {
+    using OpConversionPattern::OpConversionPattern;
+
+    LogicalResult matchAndRewrite(
+        AllocOp op,
+        AllocOpAdaptor adaptor,
+        ConversionPatternRewriter &rewriter) const override
+    {
+        rewriter.replaceOpWithNewOp<quantum::AllocOp>(
+            op,
+            quantum::QubitType::get(getContext(), 1));
+        return success();
+    }
+}; // struct ConvertAllocOp
+
+struct ConvertSwap : public OpConversionPattern<qir::SwapOp> {
+    using OpConversionPattern::OpConversionPattern;
+
+    LogicalResult matchAndRewrite(
+        qir::SwapOp op,
+        qir::SwapOpAdaptor adaptor,
+        ConversionPatternRewriter &rewriter) const override
+    {
+        // Retrieve the two input qubits from the adaptor.
+        Value qubit1 = adaptor.getLhs();
+        Value qubit2 = adaptor.getRhs();
+        rewriter.create<quantum::SWAPOp>(op.getLoc(), qubit1, qubit2);
+        rewriter.replaceOp(op, {qubit1, qubit2});
+        return success();
+    }
+};
+} // namespace
+
+void ConvertQIRToQuantumPass::runOnOperation()
+{
+    TypeConverter typeConverter;
+    auto context = &getContext();
+    ConversionTarget target(*context);
+    RewritePatternSet patterns(context);
+
+    typeConverter.addConversion([](Type ty) { return ty; });
+    typeConverter.addConversion([](quantum::QubitType ty) {
+        return qir::QubitType::get(ty.getContext());
+    });
+    typeConverter.addConversion([&](FunctionType fty) {
+        llvm::SmallVector<Type> argTypes, resTypes;
+
+        for (auto ins : fty.getInputs())
+            argTypes.push_back(typeConverter.convertType(ins));
+
+        for (auto res : fty.getResults())
+            resTypes.push_back(typeConverter.convertType(res));
+
+        return FunctionType::get(fty.getContext(), argTypes, resTypes);
+    });
+
+    qir::populateConvertQIRToQuantumPatterns(typeConverter, patterns);
+
+    target.addIllegalDialect<qir::QIRDialect>();
+    target.markUnknownOpDynamicallyLegal([](Operation* op) { return true; });
+    target.addLegalDialect<quantum::QuantumDialect>();
+    target.addLegalDialect<tensor::TensorDialect>();
+    target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+        return typeConverter.isLegal(op.getFunctionType());
+    });
+
+    if (failed(applyPartialConversion(
+            getOperation(),
+            target,
+            std::move(patterns))))
+        return signalPassFailure();
+}
+
+void mlir::qir::populateConvertQIRToQuantumPatterns(
+    TypeConverter &typeConverter,
+    RewritePatternSet &patterns)
+{
+    patterns.add<ConvertAlloc, ConvertSwap>(
+        typeConverter,
+        patterns.getContext(),
+        /* benefit*/ 1);
+}
+
+std::unique_ptr<Pass> mlir::createConvertQIRToQuantumPass()
+{
+    return std::make_unique<ConvertQIRToQuantumPass>();
+}

--- a/lib/Dialect/Quantum/IR/CMakeLists.txt
+++ b/lib/Dialect/Quantum/IR/CMakeLists.txt
@@ -14,4 +14,6 @@ add_mlir_dialect_library(QuantumIR
         QuantumEnums
         QuantumTransforms
         QIRIR
+        MLIRArithDialect
+        MLIRArithTransforms
 )

--- a/test/Conversion/QIRToQuantum/qir-to-quantum.mlir
+++ b/test/Conversion/QIRToQuantum/qir-to-quantum.mlir
@@ -1,0 +1,29 @@
+// RUN: quantum-opt -lift-qir-to-quantum | FileCheck %s
+  
+// CHECK-LABEL: func.func @main(
+// CHECK: ) -> i1 {
+func.func @main() -> (i1) {
+  // CHECK-DAG: %[[Q0:.+]] = "quantum.alloc" () : () -> (!quantum.qubit<1>)
+  %q0 = "qir.alloc" () : () -> (!qir.qubit)
+  // CHECK-DAG: %[[Q1:.+]] = "quantum.alloc" () : () -> (!quantum.qubit<1>)
+  %q1 = "qir.alloc" () : () -> (!qir.qubit)
+  // CHECK-NOT "qir.ralloc"
+  %r0 = "qir.ralloc" () : () -> (!qir.result)
+  %const1 = arith.constant 0.34 : f64
+  // CHECK-DAG: %[[Q2:.+]] = "quantum.H" (%[[Q0]]) : (!quantum.qubit<1>) -> (!quantum.qubit<1>)
+  "qir.H" (%q0) : (!qir.qubit) -> ()
+  // CHECK-DAG: %[[Q3:.+]] = "quantum.Rz" (%[[Q2]], %const1) : (!quantum.qubit<1>, f64) -> (!quantum.qubit<1>)
+  "qir.Rz" (%q0, %const1) : (!qir.qubit, f64) -> ()
+  // CHECK-DAG: %[[Q4:.+]], %[[Q5:.+]] = "quantum.SWAP" (%[[Q3]], %[[Q1]]) : (!quantum.qubit<1>, !quantum.qubit<1>) -> (!quantum.qubit<1>, !quantum.qubit<1>)
+  "qir.swap"(%q0, %q1) : (!qir.qubit, !qir.qubit) -> ()
+  // CHECK-DAG: 
+  "qir.measure" (%q0, %r0) : (!qir.qubit, !qir.result) -> ()
+  // CHECK-DAG: 
+  %mt = "qir.read_measurement" (%r0) : (!qir.result) -> (tensor<1xi1>)
+  // CHECK-DAG: 
+  "qir.reset" (%q0) : (!qir.qubit) -> ()
+  %i = "index.constant" () {value = 0 : index} : () -> (index)
+  %m = "tensor.extract" (%mt, %i) : (tensor<1xi1>, index) -> (i1)
+  // CHECK-DAG: llvm.return
+  return %m : i1
+}

--- a/test/Conversion/QIRToQuantum/qir-to-quantum.mlir
+++ b/test/Conversion/QIRToQuantum/qir-to-quantum.mlir
@@ -5,28 +5,29 @@ module {
   // CHECK-LABEL: func.func @main(
   // CHECK: ) -> tensor<1xi1> {
   func.func @main() -> (tensor<1xi1>) {
-    // CHECK-DAG: %[[Q0:.+]] = "quantum.alloc" () : () -> (!quantum.qubit<1>)
+    // CHECK-DAG: %[[Q0:.+]] = "quantum.alloc"() : () -> !quantum.qubit<1> 
     %q0 = "qir.alloc" () : () -> (!qir.qubit)
-    // CHECK-DAG: %[[Q1:.+]] = "quantum.alloc" () : () -> (!quantum.qubit<1>)
+    // CHECK-DAG: %[[Q1:.+]] = "quantum.alloc"() : () -> !quantum.qubit<1>
     %q1 = "qir.alloc" () : () -> (!qir.qubit)
     // CHECK-NOT "qir.ralloc"
     %r0 = "qir.ralloc" () : () -> (!qir.result)
+    // CHECK-DAG: %[[cst:.+]] = arith.constant 
     %const1 = arith.constant 0.34 : f64
-    // CHECK-DAG: %[[Q2:.+]] = "quantum.H" (%[[Q0]]) : (!quantum.qubit<1>) -> (!quantum.qubit<1>)
+    // CHECK-DAG: %[[Q2:.+]] = "quantum.H"(%[[Q0]]) : (!quantum.qubit<1>) -> !quantum.qubit<1>
     "qir.H" (%q0) : (!qir.qubit) -> ()
-    // CHECK-DAG: %[[Q3:.+]] = "quantum.Rz" (%[[Q2]], %const1) : (!quantum.qubit<1>, f64) -> (!quantum.qubit<1>)
+    // CHECK-DAG: %[[Q3:.+]] = "quantum.Rz"(%[[Q2]], %[[cst]]) : (!quantum.qubit<1>, f64) -> !quantum.qubit<1>
     "qir.Rz" (%q0, %const1) : (!qir.qubit, f64) -> ()
-    // CHECK-DAG: %[[Q4:.+]], %[[Q5:.+]] = "quantum.SWAP" (%[[Q3]], %[[Q1]]) : (!quantum.qubit<1>, !quantum.qubit<1>) -> (!quantum.qubit<1>, !quantum.qubit<1>)
+    // CHECK-DAG: %[[Q4:.+]], %[[Q5:.+]] = "quantum.SWAP"(%[[Q3]], %[[Q1]]) : (!quantum.qubit<1>, !quantum.qubit<1>) -> (!quantum.qubit<1>, !quantum.qubit<1>)
     "qir.swap"(%q0, %q1) : (!qir.qubit, !qir.qubit) -> ()
-    // CHECK-DAG: %[[M:.+]], %[[Q6:.+]] = "quantum.measure" (%[[Q4]]) : (!quantum.qubit<1>) -> (tensor<1xi1>, !quantum.qubit<1>)
+    // CHECK-DAG: %[[M:.+]], %[[Q6:.+]] = "quantum.measure"(%[[Q4]]) : (!quantum.qubit<1>) -> (tensor<1xi1>, !quantum.qubit<1>)
     "qir.measure" (%q0, %r0) : (!qir.qubit, !qir.result) -> ()
     // CHECK-NOT: "qir.read_measurement"
     %mt = "qir.read_measurement" (%r0) : (!qir.result) -> (tensor<1xi1>)
-    // CHECK-DAG: "quantum.deallocate" (%[[Q6]]) : (!quantum.qubit<1>) -> () 
+    // CHECK-DAG: "quantum.deallocate"(%[[Q6]]) : (!quantum.qubit<1>) -> () 
     "qir.reset" (%q0) : (!qir.qubit) -> ()
-    // CHECK-DAG: "quantum.deallocate" (%[[Q5]]) : (!quantum.qubit<1>) -> () 
+    // CHECK-DAG: "quantum.deallocate"(%[[Q5]]) : (!quantum.qubit<1>) -> () 
     "qir.reset" (%q1) : (!qir.qubit) -> ()
-    // CHECK-DAG: func.return %[[M]]
+    // CHECK-DAG: return %[[M]]
     func.return %mt : tensor<1xi1>
   }
 

--- a/test/Conversion/QIRToQuantum/qir-to-quantum.mlir
+++ b/test/Conversion/QIRToQuantum/qir-to-quantum.mlir
@@ -1,29 +1,33 @@
-// RUN: quantum-opt -lift-qir-to-quantum | FileCheck %s
-  
-// CHECK-LABEL: func.func @main(
-// CHECK: ) -> i1 {
-func.func @main() -> (i1) {
-  // CHECK-DAG: %[[Q0:.+]] = "quantum.alloc" () : () -> (!quantum.qubit<1>)
-  %q0 = "qir.alloc" () : () -> (!qir.qubit)
-  // CHECK-DAG: %[[Q1:.+]] = "quantum.alloc" () : () -> (!quantum.qubit<1>)
-  %q1 = "qir.alloc" () : () -> (!qir.qubit)
-  // CHECK-NOT "qir.ralloc"
-  %r0 = "qir.ralloc" () : () -> (!qir.result)
-  %const1 = arith.constant 0.34 : f64
-  // CHECK-DAG: %[[Q2:.+]] = "quantum.H" (%[[Q0]]) : (!quantum.qubit<1>) -> (!quantum.qubit<1>)
-  "qir.H" (%q0) : (!qir.qubit) -> ()
-  // CHECK-DAG: %[[Q3:.+]] = "quantum.Rz" (%[[Q2]], %const1) : (!quantum.qubit<1>, f64) -> (!quantum.qubit<1>)
-  "qir.Rz" (%q0, %const1) : (!qir.qubit, f64) -> ()
-  // CHECK-DAG: %[[Q4:.+]], %[[Q5:.+]] = "quantum.SWAP" (%[[Q3]], %[[Q1]]) : (!quantum.qubit<1>, !quantum.qubit<1>) -> (!quantum.qubit<1>, !quantum.qubit<1>)
-  "qir.swap"(%q0, %q1) : (!qir.qubit, !qir.qubit) -> ()
-  // CHECK-DAG: 
-  "qir.measure" (%q0, %r0) : (!qir.qubit, !qir.result) -> ()
-  // CHECK-DAG: 
-  %mt = "qir.read_measurement" (%r0) : (!qir.result) -> (tensor<1xi1>)
-  // CHECK-DAG: 
-  "qir.reset" (%q0) : (!qir.qubit) -> ()
-  %i = "index.constant" () {value = 0 : index} : () -> (index)
-  %m = "tensor.extract" (%mt, %i) : (tensor<1xi1>, index) -> (i1)
-  // CHECK-DAG: llvm.return
-  return %m : i1
+// RUN: quantum-opt %s -lift-qir-to-quantum | FileCheck %s
+
+module {
+
+  // CHECK-LABEL: func.func @main(
+  // CHECK: ) -> tensor<1xi1> {
+  func.func @main() -> (tensor<1xi1>) {
+    // CHECK-DAG: %[[Q0:.+]] = "quantum.alloc" () : () -> (!quantum.qubit<1>)
+    %q0 = "qir.alloc" () : () -> (!qir.qubit)
+    // CHECK-DAG: %[[Q1:.+]] = "quantum.alloc" () : () -> (!quantum.qubit<1>)
+    %q1 = "qir.alloc" () : () -> (!qir.qubit)
+    // CHECK-NOT "qir.ralloc"
+    %r0 = "qir.ralloc" () : () -> (!qir.result)
+    %const1 = arith.constant 0.34 : f64
+    // CHECK-DAG: %[[Q2:.+]] = "quantum.H" (%[[Q0]]) : (!quantum.qubit<1>) -> (!quantum.qubit<1>)
+    "qir.H" (%q0) : (!qir.qubit) -> ()
+    // CHECK-DAG: %[[Q3:.+]] = "quantum.Rz" (%[[Q2]], %const1) : (!quantum.qubit<1>, f64) -> (!quantum.qubit<1>)
+    "qir.Rz" (%q0, %const1) : (!qir.qubit, f64) -> ()
+    // CHECK-DAG: %[[Q4:.+]], %[[Q5:.+]] = "quantum.SWAP" (%[[Q3]], %[[Q1]]) : (!quantum.qubit<1>, !quantum.qubit<1>) -> (!quantum.qubit<1>, !quantum.qubit<1>)
+    "qir.swap"(%q0, %q1) : (!qir.qubit, !qir.qubit) -> ()
+    // CHECK-DAG: %[[M:.+]], %[[Q6:.+]] = "quantum.measure" (%[[Q4]]) : (!quantum.qubit<1>) -> (tensor<1xi1>, !quantum.qubit<1>)
+    "qir.measure" (%q0, %r0) : (!qir.qubit, !qir.result) -> ()
+    // CHECK-NOT: "qir.read_measurement"
+    %mt = "qir.read_measurement" (%r0) : (!qir.result) -> (tensor<1xi1>)
+    // CHECK-DAG: "quantum.deallocate" (%[[Q6]]) : (!quantum.qubit<1>) -> () 
+    "qir.reset" (%q0) : (!qir.qubit) -> ()
+    // CHECK-DAG: "quantum.deallocate" (%[[Q5]]) : (!quantum.qubit<1>) -> () 
+    "qir.reset" (%q1) : (!qir.qubit) -> ()
+    // CHECK-DAG: func.return %[[M]]
+    func.return %mt : tensor<1xi1>
+  }
+
 }


### PR DESCRIPTION
A QIR to Quantum lifting pass. Currently only a limited set of operations is included:

        ConvertAlloc,
        ConvertSwap,
        ConvertResultAlloc,
        ConvertH,
        ConvertRz,
        ConvertMeasure,
        ConvertReset
